### PR TITLE
Add field_area to objs, new tags table, return spawns_with_lotm

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -47,9 +47,12 @@ function parseResult(result: any): { [key: string]: any } {
 
 const FIELDS = 'objid, map_type, map_name, map_static, hash_id, unit_config_name as name, `drop`, equip, data, messageid, scale, sharp_weapon_judge_type, hard_mode, disable_rankup_for_hard_mode';
 
+const IS_LOTM = `(select (count(tag) > 0) from tags where
+actor_name = unit_config_name and tag = 'UnderGodForest') * (field_area = 64) as spawns_with_lotm`;
+
 // Returns object details for an object.
 app.get('/obj/:objid', (req, res) => {
-  const stmt = db.prepare(`SELECT ${FIELDS} FROM objs
+  const stmt = db.prepare(`SELECT ${FIELDS}, ${IS_LOTM} FROM objs
     WHERE objid = @objid LIMIT 1`);
   const result = parseResult(stmt.get({
     objid: parseInt(req.params.objid, 0),
@@ -61,7 +64,7 @@ app.get('/obj/:objid', (req, res) => {
 
 // Returns object details for an object.
 app.get('/obj/:map_type/:map_name/:hash_id', (req, res) => {
-  const stmt = db.prepare(`SELECT ${FIELDS} FROM objs
+  const stmt = db.prepare(`SELECT ${FIELDS}, ${IS_LOTM} FROM objs
     WHERE map_type = @map_type
       AND map_name = @map_name
       AND hash_id = @hash_id LIMIT 1`);
@@ -77,7 +80,7 @@ app.get('/obj/:map_type/:map_name/:hash_id', (req, res) => {
 
 // Returns the placement generation group for an object.
 app.get('/obj/:map_type/:map_name/:hash_id/gen_group', (req, res) => {
-  const result = db.prepare(`SELECT ${FIELDS} FROM objs
+  const result = db.prepare(`SELECT ${FIELDS}, ${IS_LOTM} FROM objs
     WHERE gen_group =
        (SELECT gen_group FROM objs
           WHERE map_type = @map_type
@@ -115,7 +118,7 @@ function handleReqObjs(req: express.Request, res: express.Response) {
 
   const mapNameQuery = mapName ? `AND map_name = @map_name` : '';
   const limitQuery = limit != -1 ? 'LIMIT @limit' : '';
-  const query = `SELECT ${FIELDS} FROM objs
+  const query = `SELECT ${FIELDS}, ${IS_LOTM} FROM objs
     WHERE map_type = @map_type ${mapNameQuery}
       AND objid in (SELECT rowid FROM objs_fts(@q))
     ${limitQuery}`;

--- a/app/app.ts
+++ b/app/app.ts
@@ -45,14 +45,11 @@ function parseResult(result: any): { [key: string]: any } {
   return result;
 }
 
-const FIELDS = 'objid, map_type, map_name, map_static, hash_id, unit_config_name as name, `drop`, equip, data, messageid, scale, sharp_weapon_judge_type, hard_mode, disable_rankup_for_hard_mode';
-
-const IS_LOTM = `(select (count(tag) > 0) from tags where
-actor_name = unit_config_name and tag = 'UnderGodForest') * (field_area = 64) as spawns_with_lotm`;
+const FIELDS = 'objid, map_type, map_name, map_static, hash_id, unit_config_name as name, `drop`, equip, data, messageid, scale, sharp_weapon_judge_type, hard_mode, disable_rankup_for_hard_mode, spawns_with_lotm, field_area';
 
 // Returns object details for an object.
 app.get('/obj/:objid', (req, res) => {
-  const stmt = db.prepare(`SELECT ${FIELDS}, ${IS_LOTM} FROM objs
+  const stmt = db.prepare(`SELECT ${FIELDS} FROM objs
     WHERE objid = @objid LIMIT 1`);
   const result = parseResult(stmt.get({
     objid: parseInt(req.params.objid, 0),
@@ -64,7 +61,7 @@ app.get('/obj/:objid', (req, res) => {
 
 // Returns object details for an object.
 app.get('/obj/:map_type/:map_name/:hash_id', (req, res) => {
-  const stmt = db.prepare(`SELECT ${FIELDS}, ${IS_LOTM} FROM objs
+  const stmt = db.prepare(`SELECT ${FIELDS} FROM objs
     WHERE map_type = @map_type
       AND map_name = @map_name
       AND hash_id = @hash_id LIMIT 1`);
@@ -80,7 +77,7 @@ app.get('/obj/:map_type/:map_name/:hash_id', (req, res) => {
 
 // Returns the placement generation group for an object.
 app.get('/obj/:map_type/:map_name/:hash_id/gen_group', (req, res) => {
-  const result = db.prepare(`SELECT ${FIELDS}, ${IS_LOTM} FROM objs
+  const result = db.prepare(`SELECT ${FIELDS} FROM objs
     WHERE gen_group =
        (SELECT gen_group FROM objs
           WHERE map_type = @map_type
@@ -118,7 +115,7 @@ function handleReqObjs(req: express.Request, res: express.Response) {
 
   const mapNameQuery = mapName ? `AND map_name = @map_name` : '';
   const limitQuery = limit != -1 ? 'LIMIT @limit' : '';
-  const query = `SELECT ${FIELDS}, ${IS_LOTM} FROM objs
+  const query = `SELECT ${FIELDS} FROM objs
     WHERE map_type = @map_type ${mapNameQuery}
       AND objid in (SELECT rowid FROM objs_fts(@q))
     ${limitQuery}`;


### PR DESCRIPTION
- Added field_area to table objs (from FieldMapArea.beco)
- Added new table tags 
   - `create table tags ( actor_name text, tag text )`
- All queries (except /objids and /drop) return `spawns_with_lotm` 
   - true if (field_area = 64 and unit_config_name has a tag `UnderGodForest`

Reading of Actor/ActorLink yaml files was rearranged so a yaml file is only read once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/radar/9)
<!-- Reviewable:end -->
