### PR TITLE
Return 'y' (height) for returned search items.

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -41,8 +41,7 @@ function parseResult(result: any): { [key: string]: any } {
   result.hard_mode = result.hard_mode ? true : undefined;
   // Most objects do not have DisableRankUpForMasterMode set, so don't include it unless it is set.
   result.disable_rankup_for_hard_mode = result.disable_rankup_for_hard_mode ? true : undefined;
-  result.pos = [Math.round(result.data.Translate[0] * 100) / 100, Math.round(result.data.Translate[2] * 100) / 100];
-  result.y = Math.round(result.data.Translate[1] * 100) / 100;
+  result.pos = result.data.Translate.map(v => Math.round(v * 100) / 100);
   result.korok_id = result.korok_id || undefined;
   result.korok_type = result.korok_type || undefined;
   return result;

--- a/app/app.ts
+++ b/app/app.ts
@@ -42,6 +42,7 @@ function parseResult(result: any): { [key: string]: any } {
   // Most objects do not have DisableRankUpForMasterMode set, so don't include it unless it is set.
   result.disable_rankup_for_hard_mode = result.disable_rankup_for_hard_mode ? true : undefined;
   result.pos = [Math.round(result.data.Translate[0] * 100) / 100, Math.round(result.data.Translate[2] * 100) / 100];
+  result.y = Math.round(result.data.Translate[1] * 100) / 100;
   result.korok_id = result.korok_id || undefined;
   result.korok_type = result.korok_type || undefined;
   return result;


### PR DESCRIPTION
Currently only the `x` and `z` values are returned on searched items.  Add an additional field `y` to the object.  If the `pos` field gets an additional `y` value it would require many changes, as the front end expects a `pos` field if `[x, z]`. 

Hoping to add the item's height values as static (but toggleable) tooltips for the purposes of routing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/radar/14)
<!-- Reviewable:end -->
