### PR TITLE
Add one_hit_mode to app.ts

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -47,7 +47,7 @@ function parseResult(result: any): { [key: string]: any } {
   return result;
 }
 
-const FIELDS = 'objid, map_type, map_name, map_static, hash_id, unit_config_name as name, `drop`, equip, data, messageid, scale, sharp_weapon_judge_type, hard_mode, disable_rankup_for_hard_mode, spawns_with_lotm, field_area, korok_id, korok_type';
+const FIELDS = 'objid, map_type, map_name, map_static, hash_id, unit_config_name as name, `drop`, equip, data, messageid, scale, sharp_weapon_judge_type, hard_mode, disable_rankup_for_hard_mode, spawns_with_lotm, field_area, korok_id, korok_type, one_hit_mode';
 
 // Returns object details for an object.
 app.get('/obj/:objid', (req, res) => {


### PR DESCRIPTION
Added a column `one_hit_mode` to object queries in order to facilitate displaying when an object is part of the One-hit Obliterator quest on the object map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/radar/15)
<!-- Reviewable:end -->
