### PR TITLE
Add reading Rails data and rails API endpoint

### DIFF
--- a/app/PlacementMap.ts
+++ b/app/PlacementMap.ts
@@ -29,6 +29,16 @@ export class PlacementLink {
   ) { }
 }
 
+export interface ResRail {
+  readonly '!Parameters': { [key: string]: any };
+  readonly HashId: number;
+  readonly IsClosed: boolean;
+  readonly RailPoints: any[];
+}
+export class Rail {
+  constructor(public readonly data: ResRail) { }
+}
+
 export class PlacementMap {
   constructor(public type: string, public name: string, data: any) {
     this.data = data;
@@ -38,6 +48,9 @@ export class PlacementMap {
 
   getObjs() {
     return this.objs.values();
+  }
+  getRails() {
+    return this.rails.values();
   }
 
   getObj(hashid: number): PlacementObj {
@@ -82,8 +95,12 @@ export class PlacementMap {
         destObj.linksToSelf.push(new PlacementLink(obj, link, link.DefinitionName));
       }
     }
+    for (const obj of this.data.Rails) {
+      this.rails.set(obj.HashId, new Rail(obj));
+    }
   }
 
   private data: any;
   private objs: Map<number, PlacementObj> = new Map();
+  private rails: Map<number, Rail> = new Map();
 }

--- a/build.ts
+++ b/build.ts
@@ -200,11 +200,19 @@ db.exec(`
   );
 `);
 
+db.exec(`
+   CREATE TABLE rails (
+      hash_id INTEGER NOT NULL,
+      data JSON
+   );
+`);
 
 const insertObj = db.prepare(`INSERT INTO objs
   (map_type, map_name, map_static, gen_group, hash_id, unit_config_name, ui_name, data, one_hit_mode, last_boss_mode, hard_mode, disable_rankup_for_hard_mode, scale, sharp_weapon_judge_type, 'drop', equip, ui_drop, ui_equip, messageid, region, field_area, spawns_with_lotm, korok_id, korok_type, location)
   VALUES
   (@map_type, @map_name, @map_static, @gen_group, @hash_id, @unit_config_name, @ui_name, @data, @one_hit_mode, @last_boss_mode, @hard_mode, @disable_rankup_for_hard_mode, @scale, @sharp_weapon_judge_type, @drop, @equip, @ui_drop, @ui_equip, @messageid, @region, @field_area, @spawns_with_lotm, @korok_id, @korok_type, @location)`);
+
+const insertRail = db.prepare(`INSERT INTO rails (hash_id, data) VALUES (@hash_id, @data)`);
 
 function getActorData(name: string) {
   const h = CRC32.str(name) >>> 0;
@@ -630,6 +638,9 @@ function processMap(pmap: PlacementMap, isStatic: boolean): void {
     hashIdToObjIdMap.set(obj.data.HashId, result.lastInsertRowid);
   }
 
+  for (const rail of pmap.getRails()) {
+    insertRail.run({ hash_id: rail.data.HashId, data: JSON.stringify(rail.data) });
+  }
   process.stdout.write('.\n');
 }
 


### PR DESCRIPTION
Add ability to read and return Rails data.

Stored in a new table with Rails `HashID` and the `RailPoints`

There are 6 dragon objects (2 for each dragon) that do not have proper `LinkToRails` data in their objects.  These are handled separately. All other Rails are obtained by `LinksToRails.DestUnitHashId`

All Rails are returned directly.  There are objects that use specific checkpoints, but these are not handled yet.  See https://github.com/leoetlino/botw/blob/f50b984f5e645dcf71b1c6340a8834bb1dee0153/Actor/GeneralParamList/Npc_Road_009.gparamlist.yml#L69

There is a corresponding front-end use of this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/radar/21)
<!-- Reviewable:end -->
