### PR TITLE
Improved searching by using FTS5 trigram tokenizer

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -763,7 +763,7 @@ checkKorokTypes();
 
 function createFts() {
   db.exec(`
-    CREATE VIRTUAL TABLE objs_fts USING fts5(content="", map, actor, name, data, 'drop', equip, onehit, lastboss, hard, no_rankup, scale, bonus, static, region, fieldarea, lotm, korok, korok_type, location);
+    CREATE VIRTUAL TABLE objs_fts USING fts5(content="", tokenize="trigram", map, actor, name, data, 'drop', equip, onehit, lastboss, hard, no_rankup, scale, bonus, static, region, fieldarea, lotm, korok, korok_type, location);
 
     INSERT INTO objs_fts(rowid, map, actor, name, data, 'drop', equip, onehit, lastboss, hard, no_rankup, scale, bonus, static, region, fieldarea, lotm, korok, korok_type, location)
     SELECT objid, map_type || '/' || map_name, unit_config_name, ui_name, data, ui_drop, ui_equip, one_hit_mode, last_boss_mode, hard_mode, disable_rankup_for_hard_mode, scale, sharp_weapon_judge_type, map_static, region, field_area, spawns_with_lotm, korok_id, korok_type, location FROM objs;


### PR DESCRIPTION
Improve the search ability / experience for Full Text Search.

Some searches will show different results with more objects returned (unless using NOT). 

"Exact Searches" and by hash_id `0xc0ffee99` work as in the previous version.

Increases in database size (over twice as big) and build times are expected.

Requires:
- better-sqlite3 version-7.5.3  ✅ (May 15, 2022)
- sqlite3 version-3.38.5  ✅  (May 6, 2022)


*Didn't realize all of it was this new*

resolve #22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldamods/radar/23)
<!-- Reviewable:end -->
